### PR TITLE
Future proofed for new Tomcat & dotCMS versions.  Port is now 9999.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
 	# Bridged networks make the machine appear as another physical device on
 	# your network.
 	
-	config.vm.network "forwarded_port", guest: 8080, host: 8080 
+	config.vm.network "forwarded_port", guest: 9999, host: 9999 
    
    config.vm.provider "virtualbox" do |vb|
       vb.memory = "2048"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -57,25 +57,25 @@ if [ "$installMySQL" = "true" ]; then
 	echo "Configuring dotCMS to use MySQL"
 	echo 'create database dotcms default character set = utf8 default collate = utf8_general_ci;' | mysql --password=root
 	# necessary updates in context.xml
-	cd /downloadedApps/dotcms-3.3.1/dotserver/tomcat-8.0.18/webapps/ROOT/META-INF
+	cd /downloadedApps/dotcms-3.?.*/dotserver/tomcat-8.?.*/webapps/ROOT/META-INF
 	cat context.xml | sed '29s/-->//' | sed '37s/^.*$/ -->/' | sed '47s/$/ -->/' | sed '54s/^.*$//' | sed '50s/dotcms2/dotcms/' | sed '51s/{your db user}/root/' | sed '51s/{your db password}/root/' > context.tmp
 	mv context.tmp context.xml
 fi
 #  Not necessary for most installations
-#sed -i  's/port="8080"/port="8081"/' /downloadedApps/dotcms-3.2.4/dotserver/tomcat-8.0.18/conf/server.xml #change the tomcat port
-#sed -i  's/Host name="localhost"/Host name="myHost"/' /downloadedApps/dotcms-3.2.4/dotserver/tomcat-8.0.18/conf/server.xml #update hostname for this tomcat instance
+sed -i  's/port="8080"/port="9999"/' /downloadedApps/dotcms-3.?.*/dotserver/tomcat-8.?.*/conf/server.xml #change the tomcat port
+#sed -i  's/Host name="localhost"/Host name="myHost"/' /downloadedApps/dotcms-3.?.*/dotserver/tomcat-8.?.*/conf/server.xml #update hostname for this tomcat instance
 
 echo "starting dotCMS"
-/downloadedApps/dotcms-3.3.1/bin/shutdown.sh
+/downloadedApps/dotcms-3.?.*/bin/shutdown.sh
 #Handled in the Vagrantfile
-#/downloadedApps/dotcms-3.3.1/bin/startup.sh
+#/downloadedApps/dotcms-3.?.*/bin/startup.sh
 
 echo ''
-echo 'IN A FEW MINUTES, dotCMS will be accessible at http://localhost:8080/ (from your host)'
+echo 'IN A FEW MINUTES, dotCMS will be accessible at http://localhost:9999/ (from your host)'
 echo '===== Application Credentials ====='
 echo ''
 echo '=== Admin ==='
-echo '     URL: http://localhost:8080/admin'
+echo '     URL: http://localhost:9999/admin'
 echo 'username: admin@dotcms.com'
 echo 'password: admin'
 echo ''


### PR DESCRIPTION
Bootstrap.sh file currently only works on Tomcat version x.y.z and dotCMS version a.b.c.  I updated the script to be more forgiving when a new patch level of java is out.  So, apt-get'ing to the latest versions will now work.  There is less hard coding in it now by using globs to guess the version of Tomcat.  Thus, script works on Tomcat x.*.* and dotCMS a.*.*.  I hard coded the major version since upgrades of those might actually break things.

Also, change port to 9999 since ten other things on my machine use 8080.  Like the proxy which I'm testing this testing VM with.